### PR TITLE
[222] Fixed

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -247,6 +247,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             mStartedWithNetworkConnectivityInfo = savedInstanceState.getParcelable("startedWithNetworkConnectivityInfo");
             mOpenHABVersion = savedInstanceState.getInt("openHABVersion");
             mSitemapList = savedInstanceState.getParcelableArrayList("sitemapList");
+            pagerAdapter.setOpenHABBaseUrl(openHABBaseUrl);
         }
 
         if (mSitemapList == null) {


### PR DESCRIPTION
[222] Fixed

Added Line:
`pagerAdapter.setOpenHABBaseUrl(openHABBaseUrl);`to openHABMainActivity

This set the openHABBaseUrl of pagerAdapter after a screen rotate if it was set before
